### PR TITLE
Add missing slash in links

### DIFF
--- a/pcbasic/doc/index.html
+++ b/pcbasic/doc/index.html
@@ -25,10 +25,10 @@
         </h1>
         <ul>
             <li>
-                <a href="http:/pc-basic.org/doc/1.2/">PC-BASIC 1.2 documentation</a>
+                <a href="http://pc-basic.org/doc/1.2/">PC-BASIC 1.2 documentation</a>
             </li>
             <li>
-                <a href="http:/pc-basic.org/doc/2.0/">PC-BASIC 2.0 documentation</a>
+                <a href="http://pc-basic.org/doc/2.0/">PC-BASIC 2.0 documentation</a>
             </li>
         </ul>
     </header>


### PR DESCRIPTION
I noticed the two links on the Documentation page didn't work and found these missing slashes. (I have blocked auto-redirect in my browser.)

OT/ Thank you for creating the PC-BASIC project, I just found it today but already got some enjoyment out of trying out some sample programs with it.