### PR TITLE
Make download link on homepage work again

### DIFF
--- a/pcbasic/index.html
+++ b/pcbasic/index.html
@@ -21,16 +21,16 @@
         function getNewReleaseProperties(tag_name, assets) {
             // insert specific downloads for client OS
             // without JS, generic links are left which is also OK
-            var suffix_win32 = '.msi';
-            var plat_win32 = "Windows";
-            var suffix_osx = '.dmg';
-            var plat_osx = "OS X";
-            var suffix_deb = '.deb';
-            var plat_deb = "Debian Linux"
-            var suffix_src = '.tgz';
-            var plat_src = "installation from source"
+            const suffix_win32 = '.msi';
+            const plat_win32 = "Windows";
+            const suffix_osx = '.dmg';
+            const plat_osx = "OS X";
+            const suffix_deb = '.deb';
+            const plat_deb = "Debian Linux"
+            const suffix_src = '.tgz';
+            const plat_src = "installation from source"
 
-            var releaseProperties = { platform: '', url: null };
+            const releaseProperties = { platform: '', url: null };
             var suffix = '';
 
             switch (window.navigator.platform) {
@@ -53,10 +53,10 @@
                 releaseProperties.platform = plat_src;
             }
 
-            var url_base = "https://github.com/robhagemans/pcbasic/releases/download/" + tag_name + '/';
+            const url_base = "https://github.com/robhagemans/pcbasic/releases/download/" + tag_name + '/';
 
             for (var i=0; i < assets.length; ++i) {
-                var ext = assets[i].name.slice(-4);
+                const ext = assets[i].name.slice(-4);
                 console.log(ext);
                 if (ext == suffix) {
                     releaseProperties.url = url_base + assets[i].name;
@@ -68,8 +68,8 @@
         };
 
         // get latest release from GitHub
-        var json_url = "https://api.github.com/repos/robhagemans/pcbasic/releases";
-        var request = new XMLHttpRequest();
+        const json_url = "https://api.github.com/repos/robhagemans/pcbasic/releases";
+        const request = new XMLHttpRequest();
         request.open('GET', json_url, true);
 
         request.onload = function() {
@@ -82,7 +82,7 @@
                     // and first v1 tag is latest legacy
                     if (result[i].tag_name.startsWith('v2')) {
                         console.log(result[i].tag_name);
-                        var releaseProperties = getNewReleaseProperties(result[i].tag_name, result[i].assets)
+                        const releaseProperties = getNewReleaseProperties(result[i].tag_name, result[i].assets)
                         
                         // leave generic HTML in if we weren't able to find an asset URL
                         if (releaseProperties.url == null) {

--- a/pcbasic/index.html
+++ b/pcbasic/index.html
@@ -30,7 +30,7 @@
             var suffix_src = '.tgz';
             var plat_src = "installation from source"
 
-            var releaseProperties = { platform = '', url = null };
+            var releaseProperties = { platform: '', url: null };
             var suffix = '';
 
             switch (window.navigator.platform) {

--- a/pcbasic/index.html
+++ b/pcbasic/index.html
@@ -18,38 +18,56 @@
     <title>PC-BASIC</title>
 
     <script>
-        // insert specific downloads for client OS
-        // without JS, generic links are left which is also OK
-        var suffix_win32 = '-win32.exe';
-        var plat_win32 = "Windows";
-        var suffix_osx = '-osx.dmg';
-        var plat_osx = "OS X";
-        var suffix_deb = '.deb';
-        var plat_deb = "Debian Linux"
-        var suffix_src = '.tgz';
-        var plat_src = "installation from source"
+        function getNewReleaseProperties(tag_name, assets) {
+            // insert specific downloads for client OS
+            // without JS, generic links are left which is also OK
+            var suffix_win32 = '.msi';
+            var plat_win32 = "Windows";
+            var suffix_osx = '.dmg';
+            var plat_osx = "OS X";
+            var suffix_deb = '.deb';
+            var plat_deb = "Debian Linux"
+            var suffix_src = '.tgz';
+            var plat_src = "installation from source"
 
-        switch (window.navigator.platform) {
-        case 'Win32':
-        case 'Win64':
-            suffix = suffix_win32;
-            plat = plat_win32;
-            break;
-        case 'MacIntel':
-            suffix = suffix_osx;
-            plat = plat_osx;
-            break;
-        case 'Linux x86':
-        case 'Linux x86_64':
-            suffix = suffix_deb;
-            plat = plat_deb;
-            break;
-        default:
-            suffix = suffix_src;
-            plat = plat_src
-        }
+            var releaseProperties = { platform = '', url = '' };
+            var suffix = '';
 
-        // get latest release form GitHub
+            switch (window.navigator.platform) {
+            case 'Win32':
+            case 'Win64':
+                suffix = suffix_win32;
+                releaseProperties.platform = plat_win32;
+                break;
+            case 'MacIntel':
+                suffix = suffix_osx;
+                releaseProperties.platform = plat_osx;
+                break;
+            case 'Linux x86':
+            case 'Linux x86_64':
+                suffix = suffix_deb;
+                releaseProperties.platform = plat_deb;
+                break;
+            default:
+                suffix = suffix_src;
+                releaseProperties.platform = plat_src;
+            }
+
+            var url_base = "https://github.com/robhagemans/pcbasic/releases/download/" + tag_name + '/';
+
+            for (var i=0; i < assets.length; ++i) {
+                var ext = assets[i].name.slice(-4);
+                console.log(ext);
+                if (ext == suffix) {
+                    releaseProperties.url = url_base + assets[i].name;
+                    break;
+                }
+            }
+
+            return releaseProperties; 
+        };
+
+        // get latest release from GitHub
         var json_url = "https://api.github.com/repos/robhagemans/pcbasic/releases";
         var request = new XMLHttpRequest();
         request.open('GET', json_url, true);
@@ -64,10 +82,9 @@
                     // and first v1 tag is latest legacy
                     if (result[i].tag_name.startsWith('v2')) {
                         console.log(result[i].tag_name);
-                        var url_base = "https://github.com/robhagemans/pcbasic/releases/download/"
-                                        + result[i].tag_name + "/pcbasic-" + result[i].tag_name;
-                        document.getElementById("maindownloaddesc").innerHTML = "Latest release " + result[i].tag_name + " for " + plat;
-                        document.getElementById("maindownload").setAttribute('href', url_base + suffix);
+                        var releaseProperties = getNewReleaseProperties(result[i].tag_name, result[i].assets)
+                        document.getElementById("maindownloaddesc").innerHTML = "Latest release " + result[i].tag_name + " for " + releaseProperties.platform;
+                        document.getElementById("maindownload").setAttribute('href', releaseProperties.url);
                         document.getElementById("otherdownloads").innerHTML = "[ other operating systems and older releases ]";
                         break;
                     }

--- a/pcbasic/index.html
+++ b/pcbasic/index.html
@@ -30,7 +30,7 @@
             var suffix_src = '.tgz';
             var plat_src = "installation from source"
 
-            var releaseProperties = { platform = '', url = '' };
+            var releaseProperties = { platform = '', url = null };
             var suffix = '';
 
             switch (window.navigator.platform) {
@@ -83,6 +83,12 @@
                     if (result[i].tag_name.startsWith('v2')) {
                         console.log(result[i].tag_name);
                         var releaseProperties = getNewReleaseProperties(result[i].tag_name, result[i].assets)
+                        
+                        // leave generic HTML in if we weren't able to find an asset URL
+                        if (releaseProperties.url == null) {
+                            break;
+                        }
+
                         document.getElementById("maindownloaddesc").innerHTML = "Latest release " + result[i].tag_name + " for " + releaseProperties.platform;
                         document.getElementById("maindownload").setAttribute('href', releaseProperties.url);
                         document.getElementById("otherdownloads").innerHTML = "[ other operating systems and older releases ]";

--- a/pcbasic/index.html
+++ b/pcbasic/index.html
@@ -18,7 +18,7 @@
     <title>PC-BASIC</title>
 
     <script>
-        function getNewReleaseProperties(tag_name, assets) {
+        function getNewReleaseProperties(release) {
             // insert specific downloads for client OS
             // without JS, generic links are left which is also OK
             const suffix_win32 = '.msi';
@@ -27,7 +27,6 @@
             const plat_osx = "OS X";
             const suffix_deb = '.deb';
             const plat_deb = "Debian Linux"
-            const suffix_src = '.tgz';
             const plat_src = "installation from source"
 
             const releaseProperties = { platform: '', url: null };
@@ -49,17 +48,18 @@
                 releaseProperties.platform = plat_deb;
                 break;
             default:
-                suffix = suffix_src;
+                releaseProperties.url = release.tarball_url;
                 releaseProperties.platform = plat_src;
+                return releaseProperties;
             }
 
-            const url_base = "https://github.com/robhagemans/pcbasic/releases/download/" + tag_name + '/';
+            const url_base = "https://github.com/robhagemans/pcbasic/releases/download/" + release.tag_name + '/';
 
-            for (var i=0; i < assets.length; ++i) {
-                const ext = assets[i].name.slice(-4);
+            for (var i=0; i < release.assets.length; ++i) {
+                const ext = release.assets[i].name.slice(-4);
                 console.log(ext);
                 if (ext == suffix) {
-                    releaseProperties.url = url_base + assets[i].name;
+                    releaseProperties.url = url_base + release.assets[i].name;
                     break;
                 }
             }
@@ -82,7 +82,7 @@
                     // and first v1 tag is latest legacy
                     if (result[i].tag_name.startsWith('v2')) {
                         console.log(result[i].tag_name);
-                        const releaseProperties = getNewReleaseProperties(result[i].tag_name, result[i].assets)
+                        const releaseProperties = getNewReleaseProperties(result[i]);
                         
                         // leave generic HTML in if we weren't able to find an asset URL
                         if (releaseProperties.url == null) {


### PR DESCRIPTION
The download link on the [PC-BASIC homepage](http://robhagemans.github.io/pcbasic/) currently doesn't work, and looks like it can't have worked for any of the 2.0 releases. The reason is that the way the download URL is put together seems to be based on the asset names used for the 1.2 releases.

This PR modifies the JavaScript on the homepage to retrieve the download URL in a manner similar to how the download.html page does it for 2.x releases.